### PR TITLE
Configure stm32cubeide for missing header paths

### DIFF
--- a/FTDI_OpenOCD_Debug_Fix.md
+++ b/FTDI_OpenOCD_Debug_Fix.md
@@ -1,0 +1,202 @@
+# Решение проблемы с FTDI отладчиком в OpenOCD
+
+## 🔍 Анализ ошибки
+
+```
+Error: libusb_open() failed with LIBUSB_ERROR_NOT_FOUND
+Error: no device found
+Error: unable to open ftdi device with vid 0403, pid 6010
+```
+
+Это означает, что OpenOCD не может найти ваш FTDI отладчик с VID:PID 0403:6010.
+
+## 🚨 Возможные причины:
+
+1. **Отладчик не подключен** к компьютеру
+2. **Неправильные драйверы** FTDI
+3. **Устройство занято** другим процессом
+4. **Проблемы с USB портом**
+5. **Неправильная конфигурация** OpenOCD
+
+## 🛠 Пошаговое решение:
+
+### Шаг 1: Проверить физическое подключение
+- ✅ Убедитесь, что отладчик подключен к USB порту
+- ✅ Проверьте, что все кабели надежно соединены
+- ✅ Попробуйте другой USB порт
+
+### Шаг 2: Проверить наличие устройства в системе
+
+#### Windows:
+```cmd
+# Откройте Device Manager (Диспетчер устройств)
+# Найдите устройство с VID 0403 PID 6010
+# Или выполните в командной строке:
+wmic path Win32_PnPEntity where "DeviceID like '%VID_0403&PID_6010%'" get Name,DeviceID
+```
+
+#### Linux:
+```bash
+lsusb | grep 0403:6010
+# Или более подробно:
+lsusb -v -d 0403:6010
+```
+
+### Шаг 3: Исправить конфигурацию OpenOCD
+
+Обновите ваш файл `SDK11M_FT.cfg`:
+
+```tcl
+# Исправленная версия SDK11M_FT.cfg
+adapter driver ftdi
+ftdi vid_pid 0x0403 0x6010
+ftdi layout_init 0x0408 0x0ffb
+ftdi layout_signal nSRST -oe 0x0800
+
+# Дополнительные настройки для стабильности
+adapter speed 2000
+ftdi channel 0
+```
+
+Обновите `FTDBG.cfg`:
+```tcl
+# Исправленная версия FTDBG.cfg
+source [find SDK11M_FT.cfg]
+set WORKAREASIZE 0x8000
+transport select jtag
+set CHIPNAME STM32F427VITx
+set BOARDNAME SDK1_1_M
+reset_config srst_only
+set CONNECT_UNDER_RESET 1
+
+# Дополнительные настройки
+adapter speed 2000
+reset_config srst_only srst_pulls_trst
+
+source [find target/stm32f4x.cfg]
+```
+
+### Шаг 4: Проблемы с драйверами
+
+#### Windows - Установка правильных драйверов:
+
+1. **Скачайте Zadig** с https://zadig.akeo.ie/
+2. **Подключите отладчик**
+3. **Запустите Zadig как администратор**
+4. **Options** → **List All Devices**
+5. **Выберите ваше FTDI устройство**
+6. **Установите драйвер WinUSB** или **libusbK**
+
+#### Linux - Настройка udev правил:
+
+Создайте файл `/etc/udev/rules.d/99-ftdi.rules`:
+```bash
+# FTDI devices
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6010", MODE="0664", GROUP="plugdev"
+
+# Перезагрузите правила:
+sudo udevadm control --reload-rules
+sudo udevadm trigger
+```
+
+Добавьте пользователя в группу:
+```bash
+sudo usermod -a -G plugdev $USER
+# Перелогиньтесь после этого
+```
+
+### Шаг 5: Проверка конфликтов
+
+#### Закройте конфликтующие программы:
+- **STM32CubeProgrammer**
+- **ST-Link Utility**
+- **Другие экземпляры OpenOCD**
+- **Putty/TeraTerm** (если подключены к COM портам FTDI)
+
+#### Проверьте процессы:
+```bash
+# Linux/macOS:
+ps aux | grep openocd
+pkill openocd
+
+# Windows:
+tasklist | findstr openocd
+taskkill /f /im openocd.exe
+```
+
+### Шаг 6: Альтернативные конфигурации
+
+Попробуйте упрощенную конфигурацию:
+
+```tcl
+# Минимальная рабочая конфигурация
+adapter driver ftdi
+ftdi vid_pid 0x0403 0x6010
+ftdi layout_init 0x0008 0x000b
+adapter speed 1000
+
+transport select jtag
+set CHIPNAME STM32F427VITx
+source [find target/stm32f4x.cfg]
+
+init
+reset halt
+```
+
+## 🔧 Диагностические команды:
+
+### Проверить доступность OpenOCD:
+```bash
+openocd --version
+```
+
+### Запустить с отладочной информацией:
+```bash
+openocd -f FTDBG.cfg -d3
+```
+
+### Список поддерживаемых адаптеров:
+```bash
+openocd -c "adapter list" -c "exit"
+```
+
+## ⚡ Быстрые решения:
+
+### Решение 1: Попробуйте ST-Link вместо FTDI
+Если у вас есть ST-Link отладчик:
+```tcl
+source [find interface/stlink.cfg]
+transport select hla_swd
+set CHIPNAME STM32F427VITx
+source [find target/stm32f4x.cfg]
+```
+
+### Решение 2: Проверьте другие PID для FTDI
+Некоторые FTDI устройства могут иметь другой PID:
+```tcl
+# Попробуйте эти варианты:
+ftdi vid_pid 0x0403 0x6010  # FT2232H
+ftdi vid_pid 0x0403 0x6011  # FT4232H
+ftdi vid_pid 0x0403 0x6014  # FT232H
+```
+
+### Решение 3: Использование встроенных конфигураций OpenOCD
+```bash
+# Поиск готовых конфигураций:
+find /usr/share/openocd/scripts -name "*ftdi*" -o -name "*ft2232*"
+
+# Попробуйте готовую конфигурацию:
+openocd -f interface/ftdi/minimodule.cfg -f target/stm32f4x.cfg
+```
+
+## 📋 Чек-лист проверки:
+
+- [ ] Отладчик физически подключен
+- [ ] Устройство видно в системе (Device Manager/lsusb)
+- [ ] Правильные драйверы установлены
+- [ ] Нет конфликтующих программ
+- [ ] Конфигурация OpenOCD обновлена
+- [ ] Попробованы разные USB порты
+- [ ] Проверены права доступа (Linux)
+
+После выполнения этих шагов попробуйте снова запустить отладку в STM32CubeIDE.

--- a/STM32_Include_Paths_Solution.md
+++ b/STM32_Include_Paths_Solution.md
@@ -1,0 +1,171 @@
+# Решение проблемы с путями заголовочных файлов в STM32CubeIDE
+
+## Проблема
+Компилятор в STM32CubeIDE не видит некоторые пути, в которых расположены заголовочные файлы для проекта с микроконтроллером STM32F427VITx.
+
+## Анализ конфигурации
+Из предоставленных файлов конфигурации OpenOCD:
+- **Микроконтроллер**: STM32F427VITx
+- **Плата**: SDK1_1_M  
+- **Отладчик**: FTDI-based debugger (VID: 0x0403, PID: 0x6010)
+
+## Пошаговое решение
+
+### 1. Проверка структуры проекта
+Убедитесь, что ваш проект имеет правильную структуру:
+```
+YourProject/
+├── Core/
+│   ├── Inc/           # Заголовочные файлы пользователя
+│   └── Src/           # Исходные файлы пользователя
+├── Drivers/
+│   ├── STM32F4xx_HAL_Driver/
+│   │   ├── Inc/       # HAL заголовочные файлы
+│   │   └── Src/       # HAL исходные файлы
+│   └── CMSIS/
+│       ├── Device/
+│       └── Include/
+├── Middlewares/       # Промежуточное ПО (если используется)
+└── USB_DEVICE/        # USB устройство (если используется)
+```
+
+### 2. Настройка путей включения в STM32CubeIDE
+
+#### Метод 1: Через Properties проекта
+1. Щелкните правой кнопкой мыши на проекте → **Properties**
+2. Перейдите в **C/C++ Build** → **Settings**
+3. В левой панели выберите **Tool Settings**
+4. Найдите **MCU GCC Compiler** → **Include paths**
+5. Добавьте следующие пути (нажмите кнопку **+**):
+
+```
+../Core/Inc
+../Drivers/STM32F4xx_HAL_Driver/Inc
+../Drivers/STM32F4xx_HAL_Driver/Inc/Legacy
+../Drivers/CMSIS/Device/ST/STM32F4xx/Include
+../Drivers/CMSIS/Include
+```
+
+#### Метод 2: Через файл .cproject (альтернативный способ)
+Найдите файл `.cproject` в корне проекта и убедитесь, что секция `includePath` содержит:
+
+```xml
+<option id="gnu.c.compiler.option.include.paths" superClass="gnu.c.compiler.option.include.paths" valueType="includePath">
+    <listOptionValue builtIn="false" value="../Core/Inc"/>
+    <listOptionValue builtIn="false" value="../Drivers/STM32F4xx_HAL_Driver/Inc"/>
+    <listOptionValue builtIn="false" value="../Drivers/STM32F4xx_HAL_Driver/Inc/Legacy"/>
+    <listOptionValue builtIn="false" value="../Drivers/CMSIS/Device/ST/STM32F4xx/Include"/>
+    <listOptionValue builtIn="false" value="../Drivers/CMSIS/Include"/>
+</option>
+```
+
+### 3. Проверка конфигурационных файлов
+
+#### stm32f4xx_hal_conf.h
+Убедитесь, что файл `stm32f4xx_hal_conf.h` находится в папке `Core/Inc/` и содержит правильные определения для STM32F427xx:
+
+```c
+#define STM32F427xx  // Или соответствующий вашему чипу макрос
+```
+
+#### main.h
+Проверьте, что в `main.h` правильно подключены заголовочные файлы:
+
+```c
+#include "stm32f4xx_hal.h"
+#include "stm32f4xx_hal_conf.h"
+```
+
+### 4. Дополнительные настройки компилятора
+
+#### Preprocessor Symbols
+В **MCU GCC Compiler** → **Preprocessor** добавьте:
+```
+STM32F427xx
+USE_HAL_DRIVER
+DEBUG (для отладочной версии)
+```
+
+#### Optimization Level
+Для отладки установите **Optimization Level**: `-O0` или `-Og`
+
+### 5. Очистка и пересборка проекта
+
+1. **Project** → **Clean** → выберите ваш проект
+2. **Project** → **Build Project**
+
+### 6. Возможные дополнительные пути
+
+Если используете дополнительные библиотеки, добавьте соответствующие пути:
+
+#### FreeRTOS (если используется)
+```
+../Middlewares/Third_Party/FreeRTOS/Source/include
+../Middlewares/Third_Party/FreeRTOS/Source/portable/GCC/ARM_CM4F
+../Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS
+```
+
+#### USB Device Library (если используется)
+```
+../Middlewares/ST/STM32_USB_Device_Library/Core/Inc
+../Middlewares/ST/STM32_USB_Device_Library/Class/CDC/Inc
+../USB_DEVICE/App
+../USB_DEVICE/Target
+```
+
+#### FATFS (если используется)
+```
+../Middlewares/Third_Party/FatFs/src
+../FATFS/Target
+../FATFS/App
+```
+
+### 7. Диагностика проблем
+
+#### Проверка через консоль сборки
+1. Откройте **Console** во время сборки
+2. Найдите ошибки типа: `fatal error: 'filename.h' file not found`
+3. Убедитесь, что путь к файлу добавлен в Include paths
+
+#### Использование относительных путей
+- Используйте относительные пути начинающиеся с `../`
+- Избегайте абсолютных путей (они не будут работать на других машинах)
+
+### 8. Проверка кодировки файлов
+
+Убедитесь, что все файлы используют правильную кодировку:
+1. **Window** → **Preferences**
+2. **General** → **Workspace**
+3. **Text file encoding**: UTF-8
+
+## Типичные ошибки и их решения
+
+### Ошибка: "stm32f4xx_hal.h: No such file or directory"
+**Решение**: Добавить путь `../Drivers/STM32F4xx_HAL_Driver/Inc`
+
+### Ошибка: "arm_math.h: No such file or directory"
+**Решение**: Добавить путь `../Drivers/CMSIS/Include`
+
+### Ошибка: "stm32f4xx.h: No such file or directory"
+**Решение**: Добавить путь `../Drivers/CMSIS/Device/ST/STM32F4xx/Include`
+
+### Ошибка с пользовательскими заголовочными файлами
+**Решение**: Добавить путь `../Core/Inc`
+
+## Дополнительные рекомендации
+
+1. **Всегда делайте Clean перед Build** после изменения путей включения
+2. **Проверьте регистр** - Linux чувствителен к регистру имен файлов
+3. **Используйте Forward slashes** (`/`) в путях вместо backslashes (`\`)
+4. **Избегайте пробелов** в именах папок и файлов
+5. **Обновите CubeMX** до последней версии если используете автогенерацию
+
+## Автоматическая настройка через CubeMX
+
+Если проект создан через STM32CubeMX:
+1. Откройте `.ioc` файл в CubeMX
+2. Перейдите в **Project Manager** → **Project Settings**
+3. Убедитесь, что **Toolchain/IDE** установлен на **STM32CubeIDE**
+4. Нажмите **GENERATE CODE**
+
+Это автоматически настроит все необходимые пути включения.

--- a/advanced_stm32_troubleshooting.md
+++ b/advanced_stm32_troubleshooting.md
@@ -1,0 +1,156 @@
+# Расширенная диагностика проблем с заголовочными файлами STM32CubeIDE
+
+## Если основные пути уже добавлены, но проблема остается
+
+### 🔍 Диагностические вопросы:
+
+1. **Какие именно заголовочные файлы не найдены?**
+   - Скопируйте точные ошибки из консоли сборки
+   - Пример: `fatal error: 'filename.h' file not found`
+
+2. **Используете ли вы дополнительные библиотеки?**
+   - FreeRTOS
+   - USB Device/Host
+   - FATFS
+   - LwIP (Ethernet)
+   - TouchGFX
+   - Azure RTOS (ThreadX)
+
+### 🛠 Возможные дополнительные пути включения:
+
+#### Если используется FreeRTOS:
+```
+../Middlewares/Third_Party/FreeRTOS/Source/include
+../Middlewares/Third_Party/FreeRTOS/Source/portable/GCC/ARM_CM4F
+../Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS_V2
+```
+
+#### Если используется USB:
+```
+../Middlewares/ST/STM32_USB_Device_Library/Core/Inc
+../Middlewares/ST/STM32_USB_Device_Library/Class/CDC/Inc
+../Middlewares/ST/STM32_USB_Device_Library/Class/HID/Inc
+../USB_DEVICE/App
+../USB_DEVICE/Target
+```
+
+#### Если используется FATFS:
+```
+../Middlewares/Third_Party/FatFs/src
+../FATFS/Target
+../FATFS/App
+```
+
+#### Если используется LwIP:
+```
+../Middlewares/Third_Party/LwIP/src/include
+../Middlewares/Third_Party/LwIP/system
+../LWIP/App
+../LWIP/Target
+```
+
+#### Если используется TouchGFX:
+```
+../TouchGFX/App
+../TouchGFX/target
+../TouchGFX/target/generated
+../Middlewares/ST/touchgfx/framework/include
+```
+
+### 🔧 Проверки конфигурации:
+
+#### 1. Проверить настройки Build Configuration:
+- **Project Properties** → **C/C++ Build** → **Manage Configurations**
+- Убедитесь, что пути добавлены для **всех конфигураций** (Debug/Release)
+
+#### 2. Проверить настройки Indexer:
+- **Project Properties** → **C/C++ General** → **Indexer**
+- Убедитесь, что "Enable project specific settings" отключен
+- Или добавьте пути и в секцию Indexer
+
+#### 3. Проверить кодировку и символы:
+- Убедитесь, что в путях нет кириллических символов
+- Проверьте, что нет пробелов в именах папок
+- Используйте forward slashes (`/`) вместо backslashes (`\`)
+
+### 🚨 Частые проблемы и решения:
+
+#### Проблема: "Compiler cannot find user-defined headers"
+**Возможные причины:**
+1. Заголовочные файлы находятся в подпапках Core/Inc/
+2. Используются nested includes
+
+**Решение:**
+```
+../Core/Inc
+../Core/Inc/subfolder1
+../Core/Inc/subfolder2
+```
+
+#### Проблема: "Cannot find auto-generated headers"
+**Проверить:**
+1. Файл `.ioc` сгенерирован корректно
+2. Папки `Core/Inc` и `Core/Src` существуют
+3. Перегенерировать код через CubeMX
+
+#### Проблема: "Linker cannot find definitions"
+**Добавить в Linker settings:**
+- **MCU GCC Linker** → **Libraries** → **Library search path**
+- Добавить пути к `.a` файлам библиотек
+
+### 🔄 Пошаговая диагностика:
+
+#### Шаг 1: Проверить физическое наличие файлов
+```bash
+# В терминале проекта
+find . -name "*.h" | grep "имя_файла"
+```
+
+#### Шаг 2: Проверить права доступа
+- Windows: Убедитесь, что нет блокировки антивирусом
+- Linux: Проверьте права доступа к папкам проекта
+
+#### Шаг 3: Проверить настройки workspace
+- **File** → **Switch Workspace** → убедитесь в правильном workspace
+- **Project** → **Properties** → **Resource** → проверить Location
+
+#### Шаг 4: Очистить кэш Eclipse
+1. Закрыть STM32CubeIDE
+2. Удалить папку `.metadata` в workspace
+3. Переимпортировать проект
+
+### 🛡 Экстренные решения:
+
+#### Решение 1: Временное добавление абсолютных путей
+```
+C:/path/to/your/project/Core/Inc
+C:/path/to/your/project/Drivers/STM32F4xx_HAL_Driver/Inc
+```
+*(Не рекомендуется для постоянного использования)*
+
+#### Решение 2: Копирование заголовочных файлов
+Временно скопировать проблемные заголовочные файлы в `Core/Inc/`
+
+#### Решение 3: Использование символических ссылок
+```bash
+# Linux/macOS
+ln -s ../Drivers/STM32F4xx_HAL_Driver/Inc Core/Inc/hal_inc
+```
+
+### 📋 Чек-лист для сложных случаев:
+
+- [ ] Проверены все конфигурации сборки (Debug/Release)
+- [ ] Добавлены пути для всех используемых библиотек
+- [ ] Проверена структура папок проекта
+- [ ] Очищен кэш IDE
+- [ ] Перегенерирован код через CubeMX
+- [ ] Проверены настройки Indexer
+- [ ] Проверены права доступа к файлам
+- [ ] Убраны специальные символы из путей
+
+### 💡 Дополнительные советы:
+
+1. **Используйте Project Explorer** для навигации - если файл не виден в дереве проекта, добавьте папку в проект
+2. **Проверьте .project и .cproject файлы** - они могут содержать неправильные настройки
+3. **Сравните с рабочим проектом** - создайте новый проект и сравните настройки
+4. **Обновите STM32CubeIDE** до последней версии

--- a/main_c_syntax_error_fix.md
+++ b/main_c_syntax_error_fix.md
@@ -1,0 +1,150 @@
+# Исправление ошибки "expected declaration or statement at end of input" в main.c
+
+## 🔍 Анализ ошибки
+
+Ошибка `../Core/Src/main.c:190:1: error: expected declaration or statement at end of input` указывает на **неполный или поврежденный файл main.c**.
+
+## 🚨 Возможные причины:
+
+### 1. **Отсутствует закрывающая фигурная скобка функции main()**
+Ваша функция `Error_Handler` выглядит правильно, но скорее всего проблема в том, что где-то выше не закрыта функция `main()` или другая функция.
+
+### 2. **Файл обрезан/поврежден**
+Файл `main.c` может быть неполным или поврежденным.
+
+## 🛠 Решения:
+
+### Решение 1: Проверить закрывающие скобки в main()
+Убедитесь, что функция `main()` правильно закрыта:
+
+```c
+int main(void)
+{
+  /* USER CODE BEGIN 1 */
+
+  /* USER CODE END 1 */
+
+  /* MCU Configuration--------------------------------------------------------*/
+
+  /* Reset of all peripherals, Initializes the Flash interface and the Systick. */
+  HAL_Init();
+
+  /* USER CODE BEGIN Init */
+
+  /* USER CODE END Init */
+
+  /* Configure the system clock */
+  SystemClock_Config();
+
+  /* USER CODE BEGIN SysInit */
+
+  /* USER CODE END SysInit */
+
+  /* Initialize all configured peripherals */
+  MX_GPIO_Init();
+  
+  /* USER CODE BEGIN 2 */
+
+  /* USER CODE END 2 */
+
+  /* Infinite loop */
+  /* USER CODE BEGIN WHILE */
+  while (1)
+  {
+    /* USER CODE END WHILE */
+
+    /* USER CODE BEGIN 3 */
+  }
+  /* USER CODE END 3 */
+} // ← Эта скобка должна быть обязательно!
+
+/**
+  * @brief System Clock Configuration
+  * @retval None
+  */
+void SystemClock_Config(void)
+{
+  // ... код конфигурации ...
+} // ← И эта скобка тоже!
+
+void Error_Handler(void)
+{
+  /* USER CODE BEGIN Error_Handler_Debug */
+  /* User can add his own implementation to report the HAL error return state */
+  __disable_irq();
+  while (1)
+  {
+  }
+  /* USER CODE END Error_Handler_Debug */
+}
+```
+
+### Решение 2: Добавить недостающие элементы в конец файла
+
+Добавьте в самый конец файла `main.c` (после `Error_Handler`):
+
+```c
+void Error_Handler(void)
+{
+  /* USER CODE BEGIN Error_Handler_Debug */
+  /* User can add his own implementation to report the HAL error return state */
+  __disable_irq();
+  while (1)
+  {
+  }
+  /* USER CODE END Error_Handler_Debug */
+}
+
+#ifdef  USE_FULL_ASSERT
+/**
+  * @brief  Reports the name and source line number where the assert_param error has occurred.
+  * @param  file: pointer to the source file name
+  * @param  line: assert_param error line source number
+  * @retval None
+  */
+void assert_failed(uint8_t *file, uint32_t line)
+{
+  /* USER CODE BEGIN 6 */
+  /* User can add his own implementation to report the file name and line number,
+     ex: printf("Wrong parameters value: file %s on line %d\r\n", file, line) */
+  /* USER CODE END 6 */
+}
+#endif /* USE_FULL_ASSERT */
+```
+
+### Решение 3: Перегенерировать код через CubeMX
+
+1. Откройте файл `.ioc` в STM32CubeMX
+2. Нажмите **Project Manager** → **Generate Code**
+3. Это создаст новый правильный `main.c`
+4. Скопируйте ваш пользовательский код из старого файла в соответствующие секции `/* USER CODE BEGIN */ ... /* USER CODE END */`
+
+## 🔧 Пошаговая диагностика:
+
+### Шаг 1: Проверить весь файл main.c
+1. Откройте `Core/Src/main.c`
+2. Нажмите **Ctrl+A** (выделить все)
+3. Нажмите **Ctrl+Shift+F** (автоформатирование)
+4. IDE покажет, где именно проблема со скобками
+
+### Шаг 2: Проверить количество скобок
+В любом текстовом редакторе:
+- Найти все `{` в файле
+- Найти все `}` в файле  
+- Количество должно быть одинаковым
+
+### Шаг 3: Использовать функцию поиска парных скобок
+1. Поставьте курсор на любую `{`
+2. Нажмите **Ctrl+Shift+P** (в некоторых IDE это покажет парную скобку)
+
+## ⚡ Экстренное решение:
+
+Если ничего не помогает, создайте новый проект в CubeMX с теми же настройками и скопируйте только ваш пользовательский код в секции `USER CODE`.
+
+## 🎯 Быстрая проверка:
+
+Посчитайте скобки в вашем коде:
+- Каждой открывающей `{` должна соответствовать закрывающая `}`
+- Проверьте функции `main()`, `SystemClock_Config()`, `Error_Handler()` и другие
+
+**Наиболее вероятно: пропущена закрывающая скобка `}` в функции `main()` или `SystemClock_Config()`.**

--- a/quick_fix_checklist.md
+++ b/quick_fix_checklist.md
@@ -1,0 +1,64 @@
+# Быстрый чек-лист для исправления путей в STM32CubeIDE
+
+## 🚀 Немедленные действия (5 минут)
+
+### 1. Добавить основные пути включения
+**Правый клик на проект** → **Properties** → **C/C++ Build** → **Settings** → **MCU GCC Compiler** → **Include paths**
+
+Добавить эти пути (нажать кнопку **+**):
+```
+../Core/Inc
+../Drivers/STM32F4xx_HAL_Driver/Inc
+../Drivers/STM32F4xx_HAL_Driver/Inc/Legacy
+../Drivers/CMSIS/Device/ST/STM32F4xx/Include
+../Drivers/CMSIS/Include
+```
+
+### 2. Добавить макросы препроцессора
+В том же окне: **MCU GCC Compiler** → **Preprocessor** → **Defined symbols**
+
+Добавить:
+```
+STM32F427xx
+USE_HAL_DRIVER
+DEBUG
+```
+
+### 3. Очистить и пересобрать
+- **Project** → **Clean** → выбрать проект → **Clean**
+- **Project** → **Build Project**
+
+---
+
+## 🔍 Если проблема остается
+
+### Проверить структуру папок:
+```
+YourProject/
+├── Core/Inc/          ← Должны быть ваши .h файлы
+├── Drivers/
+│   ├── STM32F4xx_HAL_Driver/Inc/  ← HAL заголовки
+│   └── CMSIS/Include/             ← CMSIS заголовки
+```
+
+### Проверить файл stm32f4xx_hal_conf.h:
+- Должен быть в `Core/Inc/`
+- Должен содержать `#define STM32F427xx`
+
+---
+
+## 📝 Быстрая диагностика
+
+### В консоли сборки ищите ошибки:
+- `fatal error: 'stm32f4xx_hal.h' file not found` → добавить HAL путь
+- `fatal error: 'arm_math.h' file not found` → добавить CMSIS путь
+- `fatal error: 'main.h' file not found` → добавить Core/Inc путь
+
+---
+
+## ⚡ Экстренное решение
+
+Если ничего не помогает:
+1. Создать новый проект в CubeMX с той же конфигурацией
+2. Скопировать ваш код в новый проект
+3. Сравнить настройки путей между проектами


### PR DESCRIPTION
Add documentation to guide users on resolving header file path issues in STM32CubeIDE.

---
<a href="https://cursor.com/background-agent?bcId=bc-2c21a7a7-d039-49be-b3a0-065df9203d3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2c21a7a7-d039-49be-b3a0-065df9203d3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

